### PR TITLE
Fix smtp username for use with SendGrid

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -35,7 +35,7 @@
   "logger": {
     "smtp": {
       "host": "smtp.sendgrid.net",
-      "username": "tosdr-bot"
+      "username": "apikey"
     },
     "sendMailOnError": {
       "to": "tosdr.alerts@gmail.com",


### PR DESCRIPTION
According to https://app.sendgrid.com/guide/integrate/langs/smtp the username should be 'apikey'